### PR TITLE
config file changes required by Splunk AppInspect

### DIFF
--- a/default/app.conf
+++ b/default/app.conf
@@ -1,12 +1,12 @@
 ## Splunk app configuration file
 
 [install]
-is_configured = true
+is_configured = false
 state = enabled
 
 [launcher]
 author=Jay Klehr
-version=1.0
+version=1.0.0
 description = This add-on provides lookup data for user-agent strings using different UA parsers
 
 [ui]


### PR DESCRIPTION
I ran this app through Splunk AppInspect. There were a couple of minor things in the config file that needed to be changed:

> [ failure ] Check that default/app.conf setting is_configured = False.
> The app.conf [install] stanza has the `is_configured` property set to true. This property indicates that a setup was already performed. File: default/app.conf Line Number: 4

and:

> [ warning ] Check that the extracted Splunk App contains a default/app.conf file that contains an [id] or [launcher] stanza with a version property that is formatted as Major.Minor.Revision.
> `Major.Minor.Revision` version numbering is required. File: default/app.conf Line Number: 9




